### PR TITLE
Refactor send_message() and send_error()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ModuBotDiscord"
-version = "0.2.0"
+version = "0.3.0"
 description = "Modular Discord bot framework built on top of ModuBotCore"
 authors = [{ name = "Endkind", email = "endkind.ender@endkind.net" }]
 readme = "README.md"


### PR DESCRIPTION
- Deprecated 'msg' parameter in send_message() and send_error(), but it's still functional for compatibility.
- send_message() now fully supports everything interaction.response.send_message() can do.
- send_message() checks if the interaction is still valid; if not, it logs instead of sending a message.
- send_error() now sends an Embed instead of plain text.
- send_error() supports 'title' and 'description' for the Embed, with a default title if none is provided.