### PR TITLE
Refactor send_message() and send_error()

### DIFF
--- a/ModuBotDiscord/commands/__init__.py
+++ b/ModuBotDiscord/commands/__init__.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 async def send_message(
     interaction: Interaction,
-    msg: Optional[str] = None,
     content: Optional[str] = None,
+    msg: Optional[str] = None,
     *,
     embed: Optional[Embed] = None,
     embeds: Optional[List[Embed]] = None,
@@ -33,13 +33,15 @@ async def send_message(
     delete_after: Optional[float] = None,
     poll=None,
 ) -> None:
-    if content is None and msg is not None:
+    if msg is not None:
         warnings.warn(
             "`msg` is deprecated, use `content` instead",
             DeprecationWarning,
             stacklevel=2,
         )
-        content = msg
+
+        if content is None:
+            content = msg
 
     if not interaction.is_expired():
         if not interaction.response.is_done():
@@ -80,9 +82,9 @@ async def send_message(
 
 async def send_error(
     interaction: Interaction,
-    msg: Optional[str] = None,
     title: str = "⚠️ An error occurred",
     description: Optional[str] = None,
+    msg: Optional[str] = None,
 ) -> None:
     if msg is not None:
         warnings.warn(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ModuBotDiscord"
-version = "0.3.0"
+version = "0.3.1"
 description = "Modular Discord bot framework built on top of ModuBotCore"
 authors = [{ name = "Endkind", email = "endkind.ender@endkind.net" }]
 readme = "README.md"


### PR DESCRIPTION
- Moved deprecated 'msg' parameter to the end in send_message() and send_error().
- send_message() now always raises a DeprecationWarning when 'msg' is used, even if 'content' is also set.