### PR TITLE
refactor: move checks and messages to utils with deprecation notices

### DIFF
--- a/ModuBotDiscord/checks/owner/__init__.py
+++ b/ModuBotDiscord/checks/owner/__init__.py
@@ -1,0 +1,1 @@
+from .check import *

--- a/ModuBotDiscord/checks/owner/check.py
+++ b/ModuBotDiscord/checks/owner/check.py
@@ -1,0 +1,73 @@
+import functools
+from typing import Awaitable, Callable, TypeVar, Union
+
+from discord import Interaction
+from ModuBotDiscord.config import DiscordConfig
+from ModuBotDiscord.utils.messages import ErrorType, send_error
+
+T = TypeVar("T", bound=Callable[..., Awaitable[None]])
+
+
+def check_bot_owner() -> Callable[[T], T]:
+    def decorator(func: T) -> T:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            interaction: Union[Interaction, None] = None
+
+            for arg in args:
+                if isinstance(arg, Interaction):
+                    interaction = arg
+                    break
+
+            if interaction is None:
+                interaction = kwargs.get("interaction")
+
+            if interaction is None:
+                raise TypeError("No Interaction found for bot owner check.")
+
+            if interaction.user.id != DiscordConfig.OWNER_ID:
+                await send_error(
+                    interaction,
+                    title=ErrorType.ACTION_NOT_ALLOWED,
+                    description="You must be the bot owner to use this command.",
+                )
+                return None
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def check_guild_owner() -> Callable[[T], T]:
+    def decorator(func: T) -> T:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            interaction: Union[Interaction, None] = None
+
+            for arg in args:
+                if isinstance(arg, Interaction):
+                    interaction = arg
+                    break
+
+            if interaction is None:
+                interaction = kwargs.get("interaction")
+
+            if interaction is None:
+                raise TypeError("No Interaction found for guild owner check.")
+
+            if (
+                not interaction.guild
+                or interaction.user.id != interaction.guild.owner_id
+            ):
+                await send_error(
+                    interaction,
+                    title=ErrorType.ACTION_NOT_ALLOWED,
+                    description="You must be the server owner to use this command.",
+                )
+                return None
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/ModuBotDiscord/checks/permissions/__init__.py
+++ b/ModuBotDiscord/checks/permissions/__init__.py
@@ -1,0 +1,2 @@
+from .check import *
+from .enum import *

--- a/ModuBotDiscord/checks/permissions/check.py
+++ b/ModuBotDiscord/checks/permissions/check.py
@@ -1,0 +1,93 @@
+import functools
+from typing import Awaitable, Callable, TypeVar, Union
+
+from discord import Interaction
+from ModuBotDiscord.utils.messages import ErrorType, send_error
+
+from .enum import Permission
+
+T = TypeVar("T", bound=Callable[..., Awaitable[None]])
+
+
+def check_permission(*permissions: Permission) -> Callable[[T], T]:
+    def decorator(func: T) -> T:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            interaction: Union[Interaction, None] = None
+
+            for arg in args:
+                if isinstance(arg, Interaction):
+                    interaction = arg
+                    break
+
+            if interaction is None:
+                interaction = kwargs.get("interaction")
+
+            if interaction is None:
+                raise ValueError("No Interaction found for user permission check.")
+
+            missing = [
+                perm.value
+                for perm in permissions
+                if not getattr(interaction.user.guild_permissions, perm.value, False)
+            ]
+            if missing:
+                missing_permissions = ", ".join(f"`{m}`" for m in missing)
+                await send_error(
+                    interaction,
+                    title=ErrorType.ACTION_NOT_ALLOWED,
+                    description=f"You are missing the following permissions: {missing_permissions}",
+                )
+                return None
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def check_bot_permission(*permissions: Permission) -> Callable[[T], T]:
+    def decorator(func: T) -> T:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            interaction: Union[Interaction, None] = None
+
+            for arg in args:
+                if isinstance(arg, Interaction):
+                    interaction = arg
+                    break
+
+            if interaction is None:
+                interaction = kwargs.get("interaction")
+
+            if interaction is None:
+                raise ValueError("No Interaction found for bot permission check.")
+
+            if not interaction.guild:
+                await send_error(
+                    interaction,
+                    title=ErrorType.ACTION_NOT_ALLOWED,
+                    description="This command can only be used in a server.",
+                )
+                return None
+
+            bot_permissions = interaction.guild.me.guild_permissions
+            missing = [
+                perm.value
+                for perm in permissions
+                if not getattr(bot_permissions, perm.value, False)
+            ]
+            if missing:
+                missing_permissions = ", ".join(f"`{m}`" for m in missing)
+                await send_error(
+                    interaction,
+                    title=ErrorType.ACTION_NOT_ALLOWED,
+                    description=f"The bot is missing the following permissions: {missing_permissions}",
+                )
+                return None
+
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/ModuBotDiscord/checks/permissions/enum.py
+++ b/ModuBotDiscord/checks/permissions/enum.py
@@ -1,8 +1,7 @@
-import warnings
 from enum import Enum
 
 
-class PermissionEnum(str, Enum):
+class Permission(str, Enum):
     ADD_REACTIONS = "add_reactions"
     ADMINISTRATOR = "administrator"
     ATTACH_FILES = "attach_files"
@@ -60,10 +59,3 @@ class PermissionEnum(str, Enum):
     VIEW_CHANNEL = "view_channel"
     VIEW_CREATOR_MONETIZATION_ANALYTICS = "view_creator_monetization_analytics"
     VIEW_GUILD_INSIGHTS = "view_guild_insights"
-
-    def __new__(cls, value):
-        warnings.warn(
-            "`ModuBotDiscord.enums.permission.PermissionEnum` is deprecated, use `ModuBotDiscord.checks.permissions.Permission` instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )

--- a/ModuBotDiscord/utils/enums.py
+++ b/ModuBotDiscord/utils/enums.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class ErrorType(Enum):
+    DEFAULT = "⚠️ An error occurred"
+    ACTION_NOT_ALLOWED = "🚫 Action not allowed"
+    VALIDATION = "❗ Invalid input"
+    TIMEOUT = "⌛ Timeout occurred"
+    NOT_FOUND = "🔍 Not found"

--- a/ModuBotDiscord/utils/messages.py
+++ b/ModuBotDiscord/utils/messages.py
@@ -1,0 +1,81 @@
+import logging
+from typing import List, Optional, Union
+
+from discord import AllowedMentions, Embed, File, Interaction, Poll
+from discord.interactions import InteractionMessage
+from discord.ui import View
+from discord.utils import MISSING, _MissingSentinel
+from discord.webhook.async_ import WebhookMessage
+
+from .enums import ErrorType
+
+logger = logging.getLogger(__name__)
+
+
+async def send_message(
+    interaction: Interaction,
+    content: Optional[str] = None,
+    *,
+    embed: Union[Embed, _MissingSentinel] = MISSING,
+    embeds: Union[List[Embed], _MissingSentinel] = MISSING,
+    file: Union[File, _MissingSentinel] = MISSING,
+    files: Union[List[File], _MissingSentinel] = MISSING,
+    view: Union[View, _MissingSentinel] = MISSING,
+    tts: bool = False,
+    ephemeral: bool = False,
+    allowed_mentions: Union[AllowedMentions, _MissingSentinel] = MISSING,
+    suppress_embeds: bool = False,
+    silent: bool = False,
+    delete_after: Optional[float] = None,
+    poll: Union[Poll, _MissingSentinel] = MISSING,
+) -> Optional[Union[InteractionMessage, WebhookMessage]]:
+    if interaction.is_expired():
+        logger.warning("Interaction is expired. Skipping send_message().")
+        return None
+
+    if interaction.response.is_done():
+        return await interaction.followup.send(
+            content=content,
+            embed=embed,
+            embeds=embeds,
+            file=file,
+            files=files,
+            view=view,
+            tts=tts,
+            ephemeral=ephemeral,
+            allowed_mentions=allowed_mentions,
+            suppress_embeds=suppress_embeds,
+            silent=silent,
+            poll=poll,
+        )
+
+    await interaction.response.send_message(
+        content=content,
+        embed=embed,
+        embeds=embeds,
+        file=file,
+        files=files,
+        view=view,
+        tts=tts,
+        ephemeral=ephemeral,
+        allowed_mentions=allowed_mentions,
+        suppress_embeds=suppress_embeds,
+        silent=silent,
+        delete_after=delete_after,
+        poll=poll,
+    )
+
+    return await interaction.original_response()
+
+
+async def send_error(
+    interaction: Interaction,
+    title: Union[str, ErrorType] = ErrorType.DEFAULT,
+    description: Optional[str] = None,
+) -> None:
+
+    if isinstance(title, ErrorType):
+        title = title.value
+
+    embed: Embed = Embed(title=title, description=description, color=0xFF0000)
+    await send_message(interaction, embed=embed, ephemeral=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ModuBotDiscord"
-version = "0.4.0"
+version = "0.5.0"
 description = "Modular Discord bot framework built on top of ModuBotCore"
 authors = [{ name = "Endkind", email = "endkind.ender@endkind.net" }]
 readme = "README.md"


### PR DESCRIPTION
- moved `check_*` decorators from `ModubotDiscord.commands.__init__` to `ModubotDiscord.utils.checks.permissions` and `ModubotDiscord.utils.checks.owner`
- moved `send_message` and `send_error` to `ModubotDiscord.utils.messages`
- added deprecation warnings for old `check_*` `send_message`, and `send_error` usages
- introduced `ErrorType` enum for standardized error titles